### PR TITLE
fix(android): gradle build tool resolution

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         //noinspection GradleDependency
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 


### PR DESCRIPTION
This version is not in the repo list anymore - jcenter removed it somehow & for some reason.  This patches to avoid issue with app builds See for more context: https://github.com/equinox-platformx/app-mobile/pull/7562

NO-TICKET